### PR TITLE
Removed output dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,6 @@
 
     dependencies_dir="dependencies"  
 
-    mkdir $output_dir;
     mkdir $dependencies_dir; 
     git clone https://github.com/aboul3la/Sublist3r.git $dependencies_dir/sublister; 
     git clone https://github.com/wpscanteam/wpscan.git $dependencies_dir/wpscan; 


### PR DESCRIPTION
Resolves #2 

As the directory `output` is already created, theres no requirement to create it again.