### PR TITLE
Change regex for more results in javascript_file_extractor.py

### DIFF
--- a/tools/javascript_files_extractor.py
+++ b/tools/javascript_files_extractor.py
@@ -33,7 +33,7 @@ for domain in domains:
 
 		matches = re.findall(regex, r, re.MULTILINE)
 		if matches == []:
-			regex = r"script src='(.*?)'"
+			regex = r'<script.*src=[\'|"](.*)[\'|"]'
 			matches = re.findall(regex, r, re.MULTILINE)
 
 		for m in matches:

--- a/tools/javascript_files_extractor.py
+++ b/tools/javascript_files_extractor.py
@@ -25,7 +25,7 @@ for domain in domains:
 	if domain != "":
 		matches = ""
 		r = ""
-		regex = r'script src="(.*?)"'
+		regex = r'<script.*src=[\'|"](.*)[\'|"]'
 		try:
 			r = requests.get("http://"+domain).content
 		except:

--- a/tools/javascript_files_extractor.py
+++ b/tools/javascript_files_extractor.py
@@ -32,9 +32,6 @@ for domain in domains:
 			print "[-]Error in http://"+domain
 
 		matches = re.findall(regex, r, re.MULTILINE)
-		if matches == []:
-			regex = r'<script.*src=[\'|"](.*)[\'|"]'
-			matches = re.findall(regex, r, re.MULTILINE)
 
 		for m in matches:
 			if domain_written != True:


### PR DESCRIPTION
Hi @003random,

I noticed that you were using this regex to quickly grab javascript files from script tags: `regex = r'script src="(.*?)"'`.  This regex doesn't find everything unfortunately, for example:


Attributes in script tags (using the current regex):
```
>>> string = "<script async src=\"/test.js\">" 
>>> regex = r'script src="(.*?)"'
>>> re.findall(regex, string, re.MULTILINE)
[]
```

Attributes in script tags (using my regex):
```
>>> string = "<script async src=\"/test.js\">" 
>>> regex = r'<script.*src=[\'|"](.*)[\'|"]'
>>> re.findall(regex, string, re.MULTILINE)
['/test.js']
```

Single quotes (using the current regex):

```
>>> string = "<script src='/test.js'>" 
>>> regex = r'script src="(.*?)"'
>>> re.findall(regex, string, re.MULTILINE)
[]
```

Single quotes (using my regex):
```
>>> string = "<script src='/test.js'>" 
>>> regex = r'<script.*src=[\'|"](.*)[\'|"]'
>>> re.findall(regex, string, re.MULTILINE)
['/test.js']
```


**EDIT:**
I noticed that you were using a different regex to find js files encapsulated in single quotes if you didn't find anything using the first regex. I suggest using this one instead since it ignores attributes in script tags.

Karel.